### PR TITLE
Installation of "openssl": "package" directive used instead of "apt_pack...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@
 #
 
 # install openssl if not present
-apt_package "openssl" do
+package "openssl" do
   action :install
 end
 


### PR DESCRIPTION
...age"
